### PR TITLE
ci: Set up initial CI and CD workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,63 @@
+name: CD
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry Run'
+        type: boolean
+        default: true
+      args:
+        description: 'Command Arguments'
+        required: false
+        type: string
+        default: ''
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  validate-release:
+    # Restricts the workflow to running, only if:
+    # 1. It isn't potentially expose a token, and is against the main branch
+    # 2. It's triggered by a release
+    if: ${{ !contains(inputs.args, '--token') || github.event_name == 'release' }}
+    uses: ./.github/workflows/ci.yml
+  publish-release:
+    needs: validate-release
+    runs-on: ubuntu-latest
+    env:
+      ARGS: ${{ inputs.args }}
+      DRY_RUN: ${{ inputs.dry_run }}
+      RELEASE: ${{ github.event_name == 'release' }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Cargo Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target/
+          key: ${{ runner.os }}-cargo-stable-${{ hashFiles('Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-stable-
+            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-
+      - name: Run Release
+        run: |
+          if $RELEASE == true; then
+            cargo publish --verbose
+          else  
+            if $DRY_RUN == true; then
+              ARGS="$ARGS --dry-run"
+            fi
+
+            cargo publish $ARGS
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'v[0-9]+.[0-0]+.x'
+    paths:
+      # `README.md` is included in `src/lib.rs` as a doc comment,
+      # meaning any changes potentially affecting it's code running,
+      # should be validated..
+      - "README.md"
+      - "**.rs"
+      - "**.toml"
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  workflow_call:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:    
+  validate-pull:
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          - beta
+          - nightly
+          - 1.56.0 # MSRV
+    steps:
+    - uses: actions/checkout@v3
+    - name: Cargo Cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin
+          ~/.cargo/registry/index
+          ~/.cargo/registry/cache
+          ~/.cargo/git/db
+          target/
+        key: ${{ runner.os }}-cargo-${{ matrix.toolchain }}-${{ hashFiles('Cargo.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-${{ matrix.toolchain }}-
+          ${{ runner.os }}-cargo-
+          ${{ runner.os }}-
+    - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }} && rustup component add clippy --toolchain ${{matrix.toolchain}}
+      # This library is designed on the stable branch, meaning the check should run on a stable version.
+    - name: Validate Formatting
+      if: matrix.toolchain == 'stable'
+      run: cargo fmt --check --verbose
+    - name: Validate Clippy
+      run: cargo clippy -- -D warnings --verbose
+    - name: Validate Tests
+      run: cargo test --verbose


### PR DESCRIPTION
This commit sets up the initial workflows for this project, notably:

- CI for validating PRs
- CD for publishing this crate to `crates.io`, following a GitHub release.