### PR TITLE
ci(ci): Switch to long flag format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,4 @@ jobs:
     - name: Validate Clippy
       run: cargo +${{ matrix.toolchain }} clippy -- -D warnings --verbose
     - name: Validate Tests
-      run: cargo +${{ matrix.toolchain }} test -F preserve_order --verbose
+      run: cargo +${{ matrix.toolchain }} test --feature preserve_order --verbose


### PR DESCRIPTION
This commit updates CI to use the long format for the `--feature` flag during the testing step, due to the fact using the short-form `-F` flag, isn't supported in the `1.56.0` version, and results in checks failing.