### PR TITLE
feat: Impl library types & behaviours

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,4 +102,4 @@ jobs:
     - name: Validate Tests
       run: cargo +${{ matrix.toolchain }} test --features preserve_order --verbose
     - name: Validate No-Std Tests
-      run: cargo +${{ matrix.toolchain }} test --no-default-features --features preserve_order alloc --verbose
+      run: cargo +${{ matrix.toolchain }} test --no-default-features --features "preserve_order alloc" --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,47 @@ jobs:
     - uses: actions/checkout@v3
     # This library is designed on the stable branch, meaning the check should run on a stable version.
     - run: cargo +stable fmt --check --verbose
+  validate-missing-feats:
+    runs-on: ubuntu-latest
+    needs: validate-formatting
+    if: ${{ !github.event.pull_request.draft }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Cargo Cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin
+          ~/.cargo/registry/index
+          ~/.cargo/registry/cache
+          ~/.cargo/git/db
+          target/
+        key: ${{ runner.os}}-cargo-stable-${{ hashFiles('Cargo.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-stable-
+          ${{ runner.os }}-cargo-
+          ${{ runner.os }}-
+    - run: rustup update stable
+    # The way the project is set up, it shouldn't be able to compile
+    # if no features are enabled, so
+    # if we trap an error when executing the script,
+    # it's behaving correctly, and should exit successfully.
+    - name: Validate No Features
+      run: |
+        trap "exit 0" ERR
+        cargo check --no-default-features
+        exit 1
+    # Due to the fact The first script will exit when an error is thrown,
+    # running the check with `serde_json/alloc` enabled,
+    # we need to add a second one.
+    - name: Validate Serde Alloc No Features
+      run: |
+        trap "exit 0" ERR
+        cargo check --no-default-features --features serde_json/alloc
+        exit 1
   validate-pull:
     # Wont be run is formatting is invalid, saving on CI resources
-    needs: validate-formatting
+    needs: validate-missing-feats
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,5 @@ jobs:
       run: cargo +${{ matrix.toolchain }} clippy -- -D warnings --verbose
     - name: Validate Tests
       run: cargo +${{ matrix.toolchain }} test --features preserve_order --verbose
+    - name: Validate No-Std Tests
+      run: cargo +${{ matrix.toolchain }} test --no-default-features --features preserve_order alloc --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ msrv = "1.56.0"
 
 [dependencies]
 serde = { version = "1.*", default-features = false, features = ["derive"] }
-serde_json = { version = "1.*", default-features = false, features = ["alloc"] }
+serde_json = { version = "1.*", default-features = false }
 
 [features]
 default = ["std"]
 std = ["alloc"]
-alloc = []
+alloc = ["serde_json/alloc"]
 rc = ["serde/rc"]
 preserve_order = ["serde_json/preserve_order"]
 arbitrary_precision = ["serde_json/arbitrary_precision"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ serde = { version = "1.*", default-features = false, features = ["derive"] }
 serde_json = { version = "1.*", default-features = false, features = ["alloc"] }
 
 [features]
+default = ["std"]
+std = ["alloc"]
+alloc = []
 rc = ["serde/rc"]
 preserve_order = ["serde_json/preserve_order"]
 arbitrary_precision = ["serde_json/arbitrary_precision"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ categories = ["web-programming", "encoding", "no-std"]
 [package.metadata]
 msrv = "1.56.0"
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 serde = { version = "1.*", default-features = false, features = ["derive"] }
 serde_json = { version = "1.*", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ impl<D, FD, ED> RJSend<D, FD, String, ED> {
     }
 }
 
-// Because `ErrorFields` is designed to map to `RJSend::Error` 
+// Because `ErrorFields` is designed to map to `RJSend::Error`
 // as directly as possible, it might be useful to have
 // an implementation which maps directly back...
 //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use core::fmt;
 #[cfg(feature = "std")]
 use std::error::Error;
 
-use serde::Deserialize;
+use serde::{ser::SerializeStruct, Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(tag = "status")]
@@ -388,6 +388,81 @@ where
 {
     fn from(data: ED) -> Self {
         Self::from_error(data)
+    }
+}
+
+// Derived implementation falls back on some funky old tricks,
+// due to the version of Rust `serde` uses,
+// which I dislike, and would prefer to streamline.
+impl<D, FD, Msg, ED> Serialize for RJSend<D, FD, Msg, ED>
+where
+    D: Serialize,
+    FD: Serialize,
+    Msg: AsRef<str>,
+    ED: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Success { data } => {
+                let mut state = serializer.serialize_struct("RJSend", 2)?;
+                // JSend resresents the different response variants
+                // via the `"status"` field, which is why during serialization,
+                // we're serializing the name of the variant as a struct field
+                // rather than serializing the enum normally...
+                state.serialize_field("status", "success")?;
+                state.serialize_field("data", data)?;
+                state.end()
+            }
+            Self::Fail { data } => {
+                let mut state = serializer.serialize_struct("RJSend", 2)?;
+                // Simlarly to above, we need to serialize
+                // the name of the variant as a struct field,
+                // to comply with the JSend standard...
+                state.serialize_field("status", "fail")?;
+                state.serialize_field("data", data)?;
+                state.end()
+            }
+            // This is the variant this custom implementation
+            // pretty much exclusively exists for,
+            // because I hate the way `serde` has to handle
+            // the `skip_serializing_if` attribute...
+            Self::Error {
+                message,
+                code,
+                data,
+            } => {
+                // Casting `bool` values as `usize` is kind of a dumb approach,
+                // but it's the most concise option in this case...
+                let some_count = code.is_some() as usize + data.is_some() as usize;
+                let mut state = serializer.serialize_struct("RJSend", 2 + some_count)?;
+
+                state.serialize_field("status", "error")?;
+                state.serialize_field("message", message.as_ref())?;
+
+                match code {
+                    // We can extract the contents using patten matching,
+                    // rather than serializing the option directly in this case,
+                    // because we want to skip serializing
+                    // in the case of a `None` value,
+                    // not encode the `None` state.
+                    Some(code) => state.serialize_field("code", code)?,
+                    None => state.skip_field("code")?,
+                }
+
+                match data {
+                    // Similarly to above, we want to skip serialization
+                    // of this field in the case a value is `None`,
+                    // rather than encode that state...
+                    Some(data) => state.serialize_field("data", data)?,
+                    None => state.skip_field("data")?,
+                }
+
+                state.end()
+            }
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,6 +278,41 @@ fn unwrap_failed(msg: &str, error: &dyn fmt::Debug) -> ! {
     panic!("{}: {:?}", msg, error)
 }
 
+// Extractor methods
+impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
+    #[inline]
+    pub fn success(self) -> Option<D> {
+        match self {
+            Self::Success { data } => Some(data),
+            _ => None,
+        }
+    }
+    
+    #[inline]
+    pub fn fail(self) -> Option<FD> {
+        match self {
+            Self::Fail { data } => Some(data),
+            _ => None,
+        }
+    }
+    
+    #[inline]
+    pub fn error(self) -> Option<ErrorFields<Msg, ED>> {
+        match self {
+            Self::Error {
+                message,
+                code,
+                data,
+            } => Some(ErrorFields {
+                message,
+                code,
+                data,
+            }),
+            _ => None,
+        }
+    }
+}
+
 // Because `ErrorFields` is designed to map to `RJSend::Error`
 // as directly as possible, it might be useful to have
 // an implementation which maps directly back...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,3 +33,8 @@ pub struct ErrorFields<Msg, ED> {
     pub code: Option<serde_json::Number>,
     pub data: Option<ED>,
 }
+
+#[cfg(not(any(feature = "std", feature = "alloc")))]
+compile_error!(
+    "rjsend requires that either the `std` feature (default) or `alloc` feature is enabled"
+);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,10 +175,16 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
     }
 
     #[inline]
+    #[allow(clippy::unwrap_or_default)]
     pub fn unwrap_or_default(self) -> D
     where
         D: Default,
     {
+        // NOTE: We need to add a linter exception here,
+        // because we are *not* using `std::option::Option`,
+        // or `std::result::Result` here,
+        // and actually *do* want to use `RJSend::unwrap_or_else` here,
+        // because we're implementing `RJSend::unwrap_or_default` here... xD
         self.unwrap_or_else(Default::default)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,26 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
+#![no_std]
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+extern crate alloc;
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
+use core::fmt;
+
+use alloc::string::String;
+use serde::Deserialize;
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(tag = "status")]
+#[serde(rename_all = "lowercase")]
+pub enum RJSend<D, FD, Msg = String, ED = serde_json::Value> {
+    Success {
+        data: D,
+    },
+    Fail {
+        data: FD,
+    },
+    Error {
+        #[serde(bound(deserialize = "Msg: fmt::Display + Deserialize<'de>",))]
+        message: Msg,
+        code: Option<serde_json::Number>,
+        data: Option<ED>,
+    },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 extern crate alloc;
 
 use core::fmt;
 
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::string::String;
 use serde::Deserialize;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,14 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-extern crate alloc;
-
 use core::fmt;
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-use alloc::string::String;
 use serde::Deserialize;
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(tag = "status")]
 #[serde(rename_all = "lowercase")]
-pub enum RJSend<D, FD, Msg = String, ED = serde_json::Value> {
+pub enum RJSend<D, FD, Msg = &'static str, ED = serde_json::Value> {
     Success {
         data: D,
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,8 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
     }
 
     #[inline]
-    #[allow(clippy::unwrap_or_default)]
+    #[allow(renamed_and_removed_lints)]
+    #[allow(clippy::unwrap_or_else_default)]
     pub fn unwrap_or_default(self) -> D
     where
         D: Default,
@@ -185,6 +186,10 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
         // or `std::result::Result` here,
         // and actually *do* want to use `RJSend::unwrap_or_else` here,
         // because we're implementing `RJSend::unwrap_or_default` here... xD
+        //
+        // Also, `unwrap_or_else_default` was quite recently renamed,
+        // making using the old name, and adding an exception to allow it,
+        // the easiest solution, whilst retaining the current implementation...
         self.unwrap_or_else(Default::default)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,7 +287,7 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
             _ => None,
         }
     }
-    
+
     #[inline]
     pub fn fail(self) -> Option<FD> {
         match self {
@@ -295,7 +295,7 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
             _ => None,
         }
     }
-    
+
     #[inline]
     pub fn error(self) -> Option<ErrorFields<Msg, ED>> {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,6 +313,62 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
     }
 }
 
+// Variant evaluation methods
+impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
+    #[inline]
+    #[must_use]
+    pub fn is_success(&self) -> bool {
+        matches!(self, Self::Success { .. })
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn is_success_and<F: FnOnce(D) -> bool>(self, f: F) -> bool {
+        match self {
+            Self::Success { data } => f(data),
+            _ => false,
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn is_fail(&self) -> bool {
+        matches!(self, Self::Fail { .. })
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn is_fail_and<F: FnOnce(FD) -> bool>(self, f: F) -> bool {
+        match self {
+            Self::Fail { data } => f(data),
+            _ => false,
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn is_error(&self) -> bool {
+        matches!(self, Self::Error { .. })
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn is_error_and<F: FnOnce(ErrorFields<Msg, ED>) -> bool>(self, f: F) -> bool {
+        match self {
+            Self::Error {
+                message,
+                code,
+                data,
+            } => f(ErrorFields {
+                message,
+                code,
+                data,
+            }),
+            _ => false,
+        }
+    }
+}
+
 // Because `ErrorFields` is designed to map to `RJSend::Error`
 // as directly as possible, it might be useful to have
 // an implementation which maps directly back...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use core::fmt;
+#[cfg(feature = "std")]
+use std::error::Error;
 
 use serde::Deserialize;
 
@@ -21,6 +23,73 @@ pub enum RJSend<D, FD, Msg = &'static str, ED = serde_json::Value> {
         code: Option<serde_json::Number>,
         data: Option<ED>,
     },
+}
+
+// Constructors functions
+impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
+    #[inline]
+    pub const fn new_error(message: Msg) -> Self {
+        Self::Error {
+            message,
+            code: None,
+            data: None,
+        }
+    }
+
+    #[inline]
+    pub fn from_error_fields(
+        ErrorFields {
+            message,
+            code,
+            data,
+        }: ErrorFields<Msg, ED>,
+    ) -> Self {
+        Self::Error {
+            message,
+            code,
+            data,
+        }
+    }
+}
+
+// `std` dependant contructor functions
+#[cfg(feature = "std")]
+impl<D, FD, ED> RJSend<D, FD, String, ED> {
+    #[inline]
+    pub fn from_error(data: ED) -> Self
+    where
+        ED: Error,
+    {
+        let message = data.to_string();
+
+        Self::Error {
+            message,
+            code: None,
+            data: Some(data),
+        }
+    }
+}
+
+// Because `ErrorFields` is designed to map to `RJSend::Error` 
+// as directly as possible, it might be useful to have
+// an implementation which maps directly back...
+//
+// This also means `ErrorFields` can be used as an ad hoc builder
+// for the variant as well...
+impl<D, FD, Msg, ED> From<ErrorFields<Msg, ED>> for RJSend<D, FD, Msg, ED> {
+    fn from(fields: ErrorFields<Msg, ED>) -> Self {
+        Self::from_error_fields(fields)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<D, FD, ED> From<ED> for RJSend<D, FD, String, ED>
+where
+    ED: Error,
+{
+    fn from(data: ED) -> Self {
+        Self::from_error(data)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
             ),
         }
     }
-  
+
     #[inline]
     #[track_caller]
     pub fn unwrap_error(self) -> ErrorFields<Msg, ED>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,3 +24,10 @@ pub enum RJSend<D, FD, Msg = String, ED = serde_json::Value> {
         data: Option<ED>,
     },
 }
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ErrorFields<Msg, ED> {
+    pub message: Msg,
+    pub code: Option<serde_json::Number>,
+    pub data: Option<ED>,
+}


### PR DESCRIPTION
Taking over from PR #5, this PR will now be used to implement the bulk of types and behaviours, relevant to this crate, notably the `RJSend` enum of this crate's namesake, and the `ErrorFields` type, for extracting the values from its `Error` variant.

Notably, this does not include deriving `Serialize` for `RJSend`, as I plan to write a custom implementation for this.

This should be functional, but will be expanded upon by other PRs in future, to flesh these out with associated implementations, and tests of these implementations.