### PR TITLE
ci(ci): Fix flag spelling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,4 @@ jobs:
     - name: Validate Clippy
       run: cargo +${{ matrix.toolchain }} clippy -- -D warnings --verbose
     - name: Validate Tests
-      run: cargo +${{ matrix.toolchain }} test --feature preserve_order --verbose
+      run: cargo +${{ matrix.toolchain }} test --features preserve_order --verbose


### PR DESCRIPTION
This commit fixes the spelling of the `--features` flag, so it doesn't cause CI runs to fail.