### PR TITLE
build: Make `std` lib optional behind default `std` feat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,47 @@ jobs:
     - uses: actions/checkout@v3
     # This library is designed on the stable branch, meaning the check should run on a stable version.
     - run: cargo +stable fmt --check --verbose
+  validate-missing-feats:
+    runs-on: ubuntu-latest
+    needs: validate-formatting
+    if: ${{ !github.event.pull_request.draft }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Cargo Cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin
+          ~/.cargo/registry/index
+          ~/.cargo/registry/cache
+          ~/.cargo/git/db
+          target/
+        key: ${{ runner.os}}-cargo-stable-${{ hashFiles('Cargo.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-stable-
+          ${{ runner.os }}-cargo-
+          ${{ runner.os }}-
+    - run: rustup update stable
+    # The way the project is set up, it shouldn't be able to compile
+    # if no features are enabled, so
+    # if we trap an error when executing the script,
+    # it's behaving correctly, and should exit successfully.
+    - name: Validate No Features
+      run: |
+        trap "exit 0" ERR
+        cargo check --no-default-features
+        exit 1
+    # Due to the fact The first script will exit when an error is thrown,
+    # running the check with `serde_json/alloc` enabled,
+    # we need to add a second one.
+    - name: Validate Serde Alloc No Features
+      run: |
+        trap "exit 0" ERR
+        cargo check --no-default-features --features serde_json/alloc
+        exit 1
   validate-pull:
     # Wont be run is formatting is invalid, saving on CI resources
-    needs: validate-formatting
+    needs: validate-missing-feats
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,5 @@ jobs:
       run: cargo +${{ matrix.toolchain }} clippy -- -D warnings --verbose
     - name: Validate Tests
       run: cargo +${{ matrix.toolchain }} test --features preserve_order --verbose
+    - name: Validate No-Std Tests
+      run: cargo +${{ matrix.toolchain }} test --no-default-features --features preserve_order alloc --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ msrv = "1.56.0"
 
 [dependencies]
 serde = { version = "1.*", default-features = false, features = ["derive"] }
-serde_json = { version = "1.*", default-features = false, features = ["alloc"] }
+serde_json = { version = "1.*", default-features = false }
 
 [features]
 default = ["std"]
 std = ["alloc"]
-alloc = []
+alloc = ["serde_json/alloc"]
 rc = ["serde/rc"]
 preserve_order = ["serde_json/preserve_order"]
 arbitrary_precision = ["serde_json/arbitrary_precision"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ serde = { version = "1.*", default-features = false, features = ["derive"] }
 serde_json = { version = "1.*", default-features = false, features = ["alloc"] }
 
 [features]
+default = ["std"]
+std = ["alloc"]
+alloc = []
 rc = ["serde/rc"]
 preserve_order = ["serde_json/preserve_order"]
 arbitrary_precision = ["serde_json/arbitrary_precision"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ categories = ["web-programming", "encoding", "no-std"]
 [package.metadata]
 msrv = "1.56.0"
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 serde = { version = "1.*", default-features = false, features = ["derive"] }
 serde_json = { version = "1.*", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,3 +33,8 @@ pub struct ErrorFields<Msg, ED> {
     pub code: Option<serde_json::Number>,
     pub data: Option<ED>,
 }
+
+#[cfg(not(any(feature = "std", feature = "alloc")))]
+compile_error!(
+    "rjsend requires that either the `std` feature (default) or `alloc` feature is enabled"
+);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 extern crate alloc;
 
 use core::fmt;
 
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::string::String;
 use serde::Deserialize;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,14 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-extern crate alloc;
-
 use core::fmt;
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-use alloc::string::String;
 use serde::Deserialize;
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(tag = "status")]
 #[serde(rename_all = "lowercase")]
-pub enum RJSend<D, FD, Msg = String, ED = serde_json::Value> {
+pub enum RJSend<D, FD, Msg = &'static str, ED = serde_json::Value> {
     Success {
         data: D,
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]


### PR DESCRIPTION
I've created this PR, because I realised it'd be useful to have the option to create features, based on members from the standard library, notably, because `Error` is not stable in `core`.

As such, this PR sets up features to allow these items to be built conditionally, as well as updating CI checks to validate these features are set up correctly.