### PR TITLE
ci(ci): Wrap list of features in quotes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,4 +102,4 @@ jobs:
     - name: Validate Tests
       run: cargo +${{ matrix.toolchain }} test --features preserve_order --verbose
     - name: Validate No-Std Tests
-      run: cargo +${{ matrix.toolchain }} test --no-default-features --features preserve_order alloc --verbose
+      run: cargo +${{ matrix.toolchain }} test --no-default-features --features "preserve_order alloc" --verbose


### PR DESCRIPTION
This commit fixes the feature specification syntax for the `Validate No-Std Tests` step in `ci.yml`, because `cargo` wasn't parsing it as a list, causing CI to fail.