### PR TITLE
feat: Add RJSend::Error variant constructors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,33 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
             data: None,
         }
     }
+
+    #[inline]
+    pub fn from_error_fields(
+        ErrorFields {
+            message,
+            code,
+            data,
+        }: ErrorFields<Msg, ED>,
+    ) -> Self {
+        Self::Error {
+            message,
+            code,
+            data,
+        }
+    }
+}
+
+// Because `ErrorFields` is designed to map to `RJSend::Error` 
+// as directly as possible, it might be useful to have
+// an implementation which maps directly back...
+//
+// This also means `ErrorFields` can be used as an ad hoc builder
+// for the variant as well...
+impl<D, FD, Msg, ED> From<ErrorFields<Msg, ED>> for RJSend<D, FD, Msg, ED> {
+    fn from(fields: ErrorFields<Msg, ED>) -> Self {
+        Self::from_error_fields(fields)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,18 @@ pub enum RJSend<D, FD, Msg = &'static str, ED = serde_json::Value> {
     },
 }
 
+// Constructors functions
+impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
+    #[inline]
+    pub const fn new_error(message: Msg) -> Self {
+        Self::Error {
+            message,
+            code: None,
+            data: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct ErrorFields<Msg, ED> {
     pub message: Msg,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use core::fmt;
+#[cfg(feature = "std")]
+use std::error::Error;
 
 use serde::Deserialize;
 
@@ -50,6 +52,24 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
     }
 }
 
+// `std` dependant contructor functions
+#[cfg(feature = "std")]
+impl<D, FD, ED> RJSend<D, FD, String, ED> {
+    #[inline]
+    pub fn from_error(data: ED) -> Self
+    where
+        ED: Error,
+    {
+        let message = data.to_string();
+
+        Self::Error {
+            message,
+            code: None,
+            data: Some(data),
+        }
+    }
+}
+
 // Because `ErrorFields` is designed to map to `RJSend::Error` 
 // as directly as possible, it might be useful to have
 // an implementation which maps directly back...
@@ -59,6 +79,16 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
 impl<D, FD, Msg, ED> From<ErrorFields<Msg, ED>> for RJSend<D, FD, Msg, ED> {
     fn from(fields: ErrorFields<Msg, ED>) -> Self {
         Self::from_error_fields(fields)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<D, FD, ED> From<ED> for RJSend<D, FD, String, ED>
+where
+    ED: Error,
+{
+    fn from(data: ED) -> Self {
+        Self::from_error(data)
     }
 }
 


### PR DESCRIPTION
As the `RJSend::Success` and `RJSend::Fail` variants are relatively simple,
I decided constructors for these variants can be omitted from the library.

By comparison, the `RJSend::Error` variant is significantly more complex,
whilst still featuring a single required field.
Consequently, constructors for this variant can be significantly more useful,
providing shorthands when the optional fields aren't required,
as well as options to map values to an instance of the type,
when their representations align.