### PR TITLE
feat: Add variant unwrapping methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,28 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
             ),
         }
     }
+
+    #[inline]
+    #[track_caller]
+    pub fn expect_error(self, msg: &str) -> ErrorFields<Msg, ED>
+    where
+        D: fmt::Debug,
+        FD: fmt::Debug,
+    {
+        match self {
+            Self::Error {
+                message,
+                code,
+                data,
+            } => ErrorFields {
+                message,
+                code,
+                data,
+            },
+            Self::Success { data } => unwrap_failed(msg, &data),
+            Self::Fail { data } => unwrap_failed(msg, &data),
+        }
+    }
 }
 
 #[inline(never)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,32 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
             ),
         }
     }
+
+    #[inline]
+    #[track_caller]
+    pub fn expect_fail(self, msg: &str) -> FD
+    where
+        D: fmt::Debug,
+        Msg: fmt::Debug,
+        ED: fmt::Debug,
+    {
+        match self {
+            Self::Fail { data } => data,
+            Self::Success { data } => unwrap_failed(msg, &data),
+            Self::Error {
+                message,
+                code,
+                data,
+            } => unwrap_failed(
+                msg,
+                &ErrorFields {
+                    message,
+                    code,
+                    data,
+                },
+            ),
+        }
+    }
 }
 
 #[inline(never)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,17 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
             _ => default,
         }
     }
+
+    #[inline]
+    pub fn unwrap_or_else<F>(self, f: F) -> D
+    where
+        F: FnOnce() -> D,
+    {
+        match self {
+            Self::Success { data } => data,
+            _ => f(),
+        }
+    }
 }
 
 // Expect methods

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,37 @@ pub enum RJSend<D, FD, Msg = &'static str, ED = serde_json::Value> {
     },
 }
 
+// Unwrapping methods
+impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
+    #[inline]
+    #[track_caller]
+    pub fn unwrap(self) -> D
+    where
+        FD: fmt::Debug,
+        Msg: fmt::Debug,
+        ED: fmt::Debug,
+    {
+        match self {
+            Self::Success { data } => data,
+            Self::Fail { data } => {
+                unwrap_failed("called `RJSend::unwrap()` on a `Fail` value", &data)
+            }
+            Self::Error {
+                message,
+                code,
+                data,
+            } => unwrap_failed(
+                "called `RJSend::unwrap()` on an `Error` value",
+                &ErrorFields {
+                    message,
+                    code,
+                    data,
+                },
+            ),
+        }
+    }
+}
+
 #[inline(never)]
 #[cold]
 #[track_caller]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,13 @@ pub enum RJSend<D, FD, Msg = &'static str, ED = serde_json::Value> {
     },
 }
 
+#[inline(never)]
+#[cold]
+#[track_caller]
+fn unwrap_failed(msg: &str, error: &dyn fmt::Debug) -> ! {
+    panic!("{}: {:?}", msg, error)
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct ErrorFields<Msg, ED> {
     pub message: Msg,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,35 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
     }
 }
 
+// Expect methods
+impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
+    #[inline]
+    #[track_caller]
+    pub fn expect(self, msg: &str) -> D
+    where
+        FD: fmt::Debug,
+        Msg: fmt::Debug,
+        ED: fmt::Debug,
+    {
+        match self {
+            Self::Success { data } => data,
+            Self::Fail { data } => unwrap_failed(msg, &data),
+            Self::Error {
+                message,
+                code,
+                data,
+            } => unwrap_failed(
+                msg,
+                &ErrorFields {
+                    message,
+                    code,
+                    data,
+                },
+            ),
+        }
+    }
+}
+
 #[inline(never)]
 #[cold]
 #[track_caller]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,14 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
             }
         }
     }
+
+    #[inline]
+    pub fn unwrap_or(self, default: D) -> D {
+        match self {
+            Self::Success { data } => data,
+            _ => default,
+        }
+    }
 }
 
 // Expect methods

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,33 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
             ),
         }
     }
+
+    #[inline]
+    #[track_caller]
+    pub fn unwrap_error(self) -> ErrorFields<Msg, ED>
+    where
+        D: fmt::Debug,
+        FD: fmt::Debug,
+    {
+        match self {
+            Self::Error {
+                message,
+                code,
+                data,
+            } => ErrorFields {
+                message,
+                code,
+                data,
+            },
+            Self::Success { data } => unwrap_failed(
+                "called `RJSend::unwrap_error()` on a `Success` value",
+                &data,
+            ),
+            Self::Fail { data } => {
+                unwrap_failed("called `RJSend::unwrap_error()` on a `Fail` value", &data)
+            }
+        }
+    }
 }
 
 #[inline(never)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,34 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
             ),
         }
     }
+
+    #[inline]
+    #[track_caller]
+    pub fn unwrap_fail(self) -> FD
+    where
+        D: fmt::Debug,
+        Msg: fmt::Debug,
+        ED: fmt::Debug,
+    {
+        match self {
+            Self::Fail { data } => data,
+            Self::Success { data } => {
+                unwrap_failed("called `RJSend::unwrap_fail()` on a `Success` value", &data)
+            }
+            Self::Error {
+                message,
+                code,
+                data,
+            } => unwrap_failed(
+                "called `RJSend::unwrap_fail` on an `Error` value",
+                &ErrorFields {
+                    message,
+                    code,
+                    data,
+                },
+            ),
+        }
+    }
 }
 
 #[inline(never)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,14 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
             _ => f(),
         }
     }
+
+    #[inline]
+    pub fn unwrap_or_default(self) -> D
+    where
+        D: Default,
+    {
+        self.unwrap_or_else(Default::default)
+    }
 }
 
 // Expect methods


### PR DESCRIPTION
As `RJSend` is effectively a result type, it's useful to provide methods
to provide shorthands for behaviour to use when extracting values
from different variants.