### PR TITLE
feat: Add option extractor methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,14 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
             _ => None,
         }
     }
+
+    #[inline]
+    pub fn fail(self) -> Option<FD> {
+        match self {
+            Self::Fail { data } => Some(data),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,22 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
             _ => None,
         }
     }
+
+    #[inline]
+    pub fn error(self) -> Option<ErrorFields<Msg, ED>> {
+        match self {
+            Self::Error {
+                message,
+                code,
+                data,
+            } => Some(ErrorFields {
+                message,
+                code,
+                data,
+            }),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,17 @@ pub enum RJSend<D, FD, Msg = &'static str, ED = serde_json::Value> {
     },
 }
 
+// Extractor methods
+impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
+    #[inline]
+    pub fn success(self) -> Option<D> {
+        match self {
+            Self::Success { data } => Some(data),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct ErrorFields<Msg, ED> {
     pub message: Msg,


### PR DESCRIPTION
These commits will add methods similar to
the `Result::ok` and `Result::err` methods in the standard library,
for each variant of `RJSend`, mapping them to an `Option`
containing its inner value, whilst discarding other variants.

As demonstrated in the standard library, this can be useful
for filtering for a particular variant, when the contents of the others
aren't of interest.