### PR TITLE
feat: Add variant evaluation methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,23 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
     pub fn is_error(&self) -> bool {
         matches!(self, Self::Error { .. })
     }
+
+    #[inline]
+    #[must_use]
+    pub fn is_error_and<F: FnOnce(ErrorFields<Msg, ED>) -> bool>(self, f: F) -> bool {
+        match self {
+            Self::Error {
+                message,
+                code,
+                data,
+            } => f(ErrorFields {
+                message,
+                code,
+                data,
+            }),
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,15 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
     pub fn is_success(&self) -> bool {
         matches!(self, Self::Success { .. })
     }
+
+    #[inline]
+    #[must_use]
+    pub fn is_success_and<F: FnOnce(D) -> bool>(self, f: F) -> bool {
+        match self {
+            Self::Success { data } => f(data),
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,12 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
             _ => false,
         }
     }
+
+    #[inline]
+    #[must_use]
+    pub fn is_error(&self) -> bool {
+        matches!(self, Self::Error { .. })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,7 +287,7 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
             _ => None,
         }
     }
-    
+
     #[inline]
     pub fn fail(self) -> Option<FD> {
         match self {
@@ -329,7 +329,7 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
             _ => false,
         }
     }
-    
+
     #[inline]
     #[must_use]
     pub fn is_fail(&self) -> bool {
@@ -344,7 +344,7 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
             _ => false,
         }
     }
-    
+
     #[inline]
     #[must_use]
     pub fn is_error(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,15 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
     pub fn is_fail(&self) -> bool {
         matches!(self, Self::Fail { .. })
     }
+
+    #[inline]
+    #[must_use]
+    pub fn is_fail_and<F: FnOnce(FD) -> bool>(self, f: F) -> bool {
+        match self {
+            Self::Fail { data } => f(data),
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,12 @@ impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
             _ => false,
         }
     }
+
+    #[inline]
+    #[must_use]
+    pub fn is_fail(&self) -> bool {
+        matches!(self, Self::Fail { .. })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,15 @@ pub enum RJSend<D, FD, Msg = &'static str, ED = serde_json::Value> {
     },
 }
 
+// Variant evaluation methods
+impl<D, FD, Msg, ED> RJSend<D, FD, Msg, ED> {
+    #[inline]
+    #[must_use]
+    pub fn is_success(&self) -> bool {
+        matches!(self, Self::Success { .. })
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct ErrorFields<Msg, ED> {
     pub message: Msg,


### PR DESCRIPTION
Shorthand methods for evaluating the variant
of a given enum value, are generally expected of enums,
which are provided by these commits.

Additionally these commits also provide methods
for evaluating both the variant, and it's contents,
in a similar vein to `Result::is_ok_and` and `Result::is_err_and`.